### PR TITLE
Add support to decimals anotations ex: 1.7d 1.5h

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ echo $duration->toMinutes(null, 0); // 62
 ```
 
 ```php
+// Configured for 6 hours per day
+$duration = new Duration('1.5d 1.5h 2m 5s', 6);
+
+echo $duration->humanize();  // 1d 4h 32m 5s
+echo $duration->formatted(); // 10:32:05
+echo $duration->toSeconds(); // 37925
+echo $duration->toMinutes(); // 632.083333333
+echo $duration->toMinutes(null, 0); // 632
+```
+
+```php
 $duration = new Duration('4293');
 
 echo $duration->humanize();  // 1h 11m 33s

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -30,8 +30,8 @@ class Duration
         $this->seconds = 0;
 
         $this->output = '';
-        $this->daysRegex = '/([0-9]{1,2})\s?(?:d|D)/';
-        $this->hoursRegex = '/([0-9]{1,2})\s?(?:h|H)/';
+        $this->daysRegex = '/([0-9\.]+)\s?(?:d|D)/';
+        $this->hoursRegex = '/([0-9\.]+)\s?(?:h|H)/';
         $this->minutesRegex = '/([0-9]{1,2})\s?(?:m|M)/';
         $this->secondsRegex = '/([0-9]{1,2}(\.\d+)?)\s?(?:s|S)/';
 
@@ -102,19 +102,23 @@ class Duration
             preg_match($this->minutesRegex, $duration) ||
             preg_match($this->secondsRegex, $duration)) {
             if (preg_match($this->daysRegex, $duration, $matches)) {
-                $this->days = (int)$matches[1];
+                $num = $this->numberBreakdown((float) $matches[1]);
+                $this->days += (int)$num[0];
+                $this->hours += $num[1] * $this->hoursPerDay;                
             }
 
             if (preg_match($this->hoursRegex, $duration, $matches)) {
-                $this->hours = (int)$matches[1];
+                $num = $this->numberBreakdown((float) $matches[1]);            
+                $this->hours += (int)$num[0];
+                $this->minutes += $num[1] * 60;                       
             }
 
             if (preg_match($this->minutesRegex, $duration, $matches)) {
-                $this->minutes = (int)$matches[1];
+                $this->minutes += (int)$matches[1];
             }
 
             if (preg_match($this->secondsRegex, $duration, $matches)) {
-                $this->seconds = (float)$matches[1];
+                $this->seconds += (float)$matches[1];
             }
 
             return $this;
@@ -255,6 +259,29 @@ class Duration
         }
 
         return trim($this->output());
+    }
+
+
+    private function numberBreakdown($number, $returnUnsigned = false)
+    {
+        $negative = 1;
+
+        if ($number < 0) {
+            $negative = -1;
+            $number *= -1;
+        }
+
+        if ($returnUnsigned) {
+            return array(
+                floor($number),
+                ($number - floor($number))
+            );
+        }
+
+        return array(
+            floor($number) * $negative,
+            ($number - floor($number)) * $negative
+        );
     }
 
 

--- a/test/DurationTest.php
+++ b/test/DurationTest.php
@@ -325,4 +325,26 @@ class DurationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(91800, $d->toSeconds('2d 11h 30m'));
     }
 
+    public function testSupportDecimals()
+    {
+        $d = new Duration(null, 6);
+        
+        $this->assertEquals(6 * 60, $d->toMinutes('1d'));
+        $this->assertEquals((6 + 3) * 60, $d->toMinutes('1.5d'));
+        $this->assertEquals(60, $d->toMinutes('1h'));
+        $this->assertEquals(60 + 30, $d->toMinutes('1.5h'));
+        $this->assertEquals((12 * 60) + 60 + 30, $d->toMinutes('2d 1.5h'));        
+    }
+
+    public function testConvertHumanizedWithSupportDecimals()
+    {
+        $t = '1.5d 1.5h 2m 5s';    
+        
+        $this->assertEquals('1d 4h 32m 5s', (new Duration($t, 6))->humanize(), "Test humanize with: {$t}");
+        $this->assertEquals('10:32:05', (new Duration($t, 6))->formatted(), "Test formatted with: {$t}");
+        $this->assertEquals(37925, (new Duration($t, 6))->toSeconds(), "Test toSeconds with: {$t}");
+        $this->assertEquals(37925/60, (new Duration($t, 6))->toMinutes(), "Test toMinutes with: {$t}");
+        $this->assertEquals(632, (new Duration($t, 6))->toMinutes(null, 0), "Test toMinutes with: {$t}");    
+    }    
+
 }


### PR DESCRIPTION
## Examples:

```php
// Configured for 6 hours per day
$duration = new Duration('1.5d 1.5h 2m 5s', 6);

echo $duration->humanize();  // 1d 4h 32m 5s
echo $duration->formatted(); // 10:32:05
echo $duration->toSeconds(); // 37925
echo $duration->toMinutes(); // 632.083333333
echo $duration->toMinutes(null, 0); // 632
```