### PR TITLE
feat(package): add `.gitattributes` file to control package contents

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/test/              export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpstan.neon.dist  export-ignore
+/phpunit.xml        export-ignore


### PR DESCRIPTION
With this change files from tests/phpstan/phpunit/CI/etc will NOT be added to archive, so projects that depends on this package will NOT have unneeded files.

Article from PHP.watch about .gitattributes - https://php.watch/articles/composer-gitattributes